### PR TITLE
Add common.min.js to Drupal header

### DIFF
--- a/guswds.info.yml
+++ b/guswds.info.yml
@@ -7,6 +7,7 @@ base theme: stable
 
 libraries:
   - guswds/global
+  - guswds/common
 
 libraries-override:
   core/drupal.dropbutton:


### PR DESCRIPTION
common.min.js is needed to initiate the USWDS mobile menu. 

1. I'm not sure if this was intentionally left out, if so please ignore
2. I'm not sure if this is the correct way to add common.min.js