### PR TITLE
cleaned up tooltip markup and examples

### DIFF
--- a/source/_patterns/03-uswds/tooltip/tooltip.md
+++ b/source/_patterns/03-uswds/tooltip/tooltip.md
@@ -7,6 +7,8 @@ See [https://designsystem.digital.gov/components/tooltip/]().
 __Variables:__
 * is_demo: [boolean] Whether to show extra demo examples.
 * modifier_classes: [string] Classes to modify the default component styling.
+* tooltip_position: [string] Tooltip position (options: top, bottom, left, right).
+* tooltip_text: [string] Text of the tooltip popup.
 * element: [string] HTML element of tooltip
 * url: [string] URL of the tooltip.
-* text: [string] Text of the tooltip.
+* text: [string] Text of the tooltip element.

--- a/source/_patterns/03-uswds/tooltip/tooltip.twig
+++ b/source/_patterns/03-uswds/tooltip/tooltip.twig
@@ -3,13 +3,19 @@
   modifier_classes ? modifier_classes,
 ]|join(' ')|trim %}
 
-<{{ element ?: 'span' }} class="{{ classes }}" title="{{ tooltip_text}}"{% if element == 'a' and url %} href="{{ url }}"{% endif %}>{{ text }}</{{ element ?: 'span' }}>
+<{{ element ?: 'span' }} class="{{ classes }}" title="{{ tooltip_text }}"{% if tooltip_position %} data-position="{{ tooltip_position }}"{% endif %}{% if element == 'a' and url %} href="{{ url }}"{% endif %}>{{ text }}</{{ element ?: 'span' }}>
 
 {% if is_demo %}
-  <div class="l-grid l-grid--4-col u-spaced-5-above">
+  <div class="u-spaced-5-above">
     <span class="usa-tooltip" title="Tooltip" data-position="top">Show on Top</span>
+  </div>
+  <div class="u-spaced-5-above">
     <span class="usa-tooltip" title="Tooltip" data-position="right">Show on Right</span>
+  </div>
+  <div class="u-spaced-5-above">
     <span class="usa-tooltip" title="Tooltip" data-position="bottom">Show on Bottom</span>
+  </div>
+  <div class="u-spaced-5-above">
     <span class="usa-tooltip" title="Tooltip" data-position="left">Show on Left</span>
   </div>
 {% endif %}

--- a/source/_patterns/03-uswds/tooltip/tooltip.yml
+++ b/source/_patterns/03-uswds/tooltip/tooltip.yml
@@ -2,4 +2,5 @@
 is_demo: true
 modifier_classes: ''
 tooltip_text: 'Tooltip'
+tooltip_position: 'top'
 text: 'Element with tooltip'


### PR DESCRIPTION
Cleans up the markup for tooltips to improve their display in Pattern Lab and adds a variable to designate position.