### PR TITLE
Remove component-specific imports from USWDS

### DIFF
--- a/js/src/modules/navigation.js
+++ b/js/src/modules/navigation.js
@@ -1,5 +1,3 @@
-import navigation from 'uswds/src/js/components/navigation.js';
-
 export default function () {
   const subnav = document.querySelectorAll('.menu__subnav');
   subnav.forEach((menu, index) => {
@@ -10,5 +8,4 @@ export default function () {
       button.setAttribute('aria-controls', id);
     }
   });
-  navigation.on(document.body);
 }

--- a/js/src/scripts.es6.js
+++ b/js/src/scripts.es6.js
@@ -4,11 +4,8 @@
 // include it on a template-specific script file instead.
 // Be sure to initialize any components as well (see init() function below.)
 import domready from 'domready';
-import accordion from 'uswds/src/js/components/accordion.js';
+import 'uswds';
 import navigation from './modules/navigation';
-import banner from 'uswds/src/js/components/banner.js';
-import tooltip from 'uswds/src/js/components/tooltip.js';
-import table from 'uswds/src/js/components/table.js';
 import backToTop from './modules/_back-to-top.es6';
 
 (function () {
@@ -33,10 +30,6 @@ import backToTop from './modules/_back-to-top.es6';
 
   // Any scripts you want to initialize once the DOM is ready go here.
   domready(() => {
-    accordion.on(document.body);
-    banner.on(document.body);
-    tooltip.on(document.body);
-    table.on(document.body);
     navigation(); // If used with the USWDS accordion component, the navigation must run after it.
     backToTop();
   });


### PR DESCRIPTION
Closes #96. Replaces the specific imports with an import of `uswds` so as to only import the file allowed in the USWDS package.json's `exports` key. 

Relevant USWDS issue: https://github.com/uswds/uswds/issues/4194