### PR TITLE
[120] Common js missing

### DIFF
--- a/guswds.libraries.yml
+++ b/guswds.libraries.yml
@@ -1,7 +1,3 @@
-common:
-  version: VERSION
-  js:
-    js/dist/common.min.js: {}
 global:
   version: VERSION
   css:

--- a/guswds.theme
+++ b/guswds.theme
@@ -13,3 +13,19 @@ require_once dirname(__FILE__) . '/includes/media.inc';
 require_once dirname(__FILE__) . '/includes/navigation.inc';
 require_once dirname(__FILE__) . '/includes/taxonomy.inc';
 require_once dirname(__FILE__) . '/includes/views.inc';
+
+/**
+ * Implements hook_library_info_build().
+ */
+function guswds_library_info_build() {
+  $libraries = [];
+  $active_theme = \Drupal::theme()->getActiveTheme()->getPath();
+  if (file_exists($active_theme . '/js/dist/common.min.js')) {
+    $libraries['common'] = [
+      'js' => [
+        'js/dist/common.min.js' => []
+      ]
+    ];
+  }
+  return $libraries;
+}

--- a/guswds.theme
+++ b/guswds.theme
@@ -9,23 +9,8 @@ require_once dirname(__FILE__) . '/includes/block.inc';
 require_once dirname(__FILE__) . '/includes/field.inc';
 require_once dirname(__FILE__) . '/includes/form.inc';
 require_once dirname(__FILE__) . '/includes/html.inc';
+require_once dirname(__FILE__) . '/includes/libraries.inc';
 require_once dirname(__FILE__) . '/includes/media.inc';
 require_once dirname(__FILE__) . '/includes/navigation.inc';
 require_once dirname(__FILE__) . '/includes/taxonomy.inc';
 require_once dirname(__FILE__) . '/includes/views.inc';
-
-/**
- * Implements hook_library_info_build().
- */
-function guswds_library_info_build() {
-  $libraries = [];
-  $active_theme = \Drupal::theme()->getActiveTheme()->getPath();
-  if (file_exists($active_theme . '/js/dist/common.min.js')) {
-    $libraries['common'] = [
-      'js' => [
-        'js/dist/common.min.js' => []
-      ]
-    ];
-  }
-  return $libraries;
-}

--- a/includes/libraries.inc
+++ b/includes/libraries.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Library-related hook implementations.
+ */
+
+/**
+ * Implements hook_library_info_build().
+ */
+function guswds_library_info_build() {
+  $libraries = [];
+  $active_theme = \Drupal::theme()->getActiveTheme()->getPath();
+  if (file_exists($active_theme . '/js/dist/common.min.js')) {
+    $libraries['common'] = [
+      'js' => [
+        'js/dist/common.min.js' => []
+      ]
+    ];
+  }
+  return $libraries;
+}

--- a/includes/libraries.inc
+++ b/includes/libraries.inc
@@ -14,8 +14,8 @@ function guswds_library_info_build() {
   if (file_exists($active_theme . '/js/dist/common.min.js')) {
     $libraries['common'] = [
       'js' => [
-        'js/dist/common.min.js' => []
-      ]
+        'js/dist/common.min.js' => [],
+      ],
     ];
   }
   return $libraries;


### PR DESCRIPTION
Probably the easiest way to test is to test both this PR and https://github.com/forumone/gesso/pull/470. In both cases, run `f1 run gesso gulp build` (or whatever equivalent command depending on how you're set up locally) followed by `f1 drush cr` and make sure JS aggregation is off. On GUSWDS, you should not see common.min.js being loaded. On Gesso, you should. Either way, you shouldn't get any errors about a missing library or missing JS file.