### PR TITLE
Tweak form templates to use USWDS (optional)

### DIFF
--- a/source/04-components/fieldset/_fieldset.scss
+++ b/source/04-components/fieldset/_fieldset.scss
@@ -41,7 +41,6 @@ $fieldset-disabled-opacity: 0.35 !default;
 // .c-fieldset__content {}
 
 .c-fieldset__description {
-  color: gesso-color(text, secondary);
   font-size: font-size(body, 3xs);
 
   > :last-child {

--- a/source/04-components/fieldset/fieldset--form-item.yml
+++ b/source/04-components/fieldset/fieldset--form-item.yml
@@ -1,9 +1,0 @@
----
-legend:
-  title: 'Fieldset'
-children: |-
-  <p>Fieldset content goes here&hellip;</p>
-description:
-  title: |-
-    <p>The description for this fieldset.</p>
-is_disabled: false

--- a/source/04-components/fieldset/fieldset.stories.jsx
+++ b/source/04-components/fieldset/fieldset.stories.jsx
@@ -12,6 +12,7 @@ const Default = args => (
   parse(twigTemplate({
     ...args,
     modifier_classes: 'c-fieldset--default',
+    hide_optional_hint: true
   }))
 );
 Default.args = { ...data };

--- a/source/04-components/fieldset/fieldset.stories.jsx
+++ b/source/04-components/fieldset/fieldset.stories.jsx
@@ -2,36 +2,17 @@ import parse from 'html-react-parser';
 
 import twigTemplate from './fieldset.twig';
 import data from './fieldset.yml';
-import formItemData from './fieldset--form-item.yml';
 
 const settings = {
   title: 'Components/Fieldset',
 };
 
-const Default = args => (
+const Fieldset = args => (
   parse(twigTemplate({
     ...args,
-    modifier_classes: 'c-fieldset--default',
-    hide_optional_hint: true
   }))
 );
-Default.args = { ...data };
-
-const Checkboxes = args => (
-  parse(twigTemplate({
-    ...args,
-    modifier_classes: 'c-fieldset--checkboxes',
-  }))
-);
-Checkboxes.args = { ...formItemData };
-
-const Radios = args => (
-  parse(twigTemplate({
-    ...args,
-    modifier_classes: 'c-fieldset--radios',
-  }))
-);
-Radios.args = { ...formItemData };
+Fieldset.args = { ...data };
 
 export default settings;
-export { Default, Checkboxes, Radios };
+export { Fieldset };

--- a/source/04-components/fieldset/fieldset.twig
+++ b/source/04-components/fieldset/fieldset.twig
@@ -37,7 +37,10 @@
 <fieldset {{ add_attributes(attributes_to_add) }}>
   {#  Always wrap fieldset legends in a <span> for CSS positioning. #}
   <legend {{ add_attributes({class: 'c-fieldset__legend'}, 'legend.attributes') }}>
-    <span {{ add_attributes({class: legend_span_classes}, 'legend_span.attributes') }}>{{ legend.title }}</span>
+    <span {{ add_attributes({class: legend_span_classes}, 'legend_span.attributes') }}>
+      {{ legend.title }}
+      {% if not required and not is_required and not hide_optional_hint %}<span class="usa-hint">{{ '(optional)'|t }}</span>{% endif %}
+    </span>
   </legend>
   <div class="c-fieldset__content">
     {% if errors %}
@@ -55,7 +58,7 @@
     {% endif %}
 
     {% if description.content %}
-      <div {{ add_attributes({class: 'c-fieldset__description', id: id}, 'description.attributes') }}>{{ description.content }}</div>
+      <div {{ add_attributes({class: 'c-fieldset__description usa-hint', id: id}, 'description.attributes') }}>{{ description.content }}</div>
     {% endif %}
   </div>
 </fieldset>

--- a/source/04-components/fieldset/fieldset.yml
+++ b/source/04-components/fieldset/fieldset.yml
@@ -6,5 +6,6 @@ children: |-
 description:
   content: |-
     <p>The description for this fieldset.</p>
-modifier_classes: ''
+modifier_classes: 'c-fieldset--default'
 id: 'fieldset'
+hide_optional_hint: false

--- a/source/04-components/form-item/_form-item-label.twig
+++ b/source/04-components/form-item/_form-item-label.twig
@@ -19,12 +19,10 @@
 <label {{ add_attributes(attributes_to_add) }}>
   {{- title }}
 
-  {% if is_required %}
+  {% if not is_required and not hide_optional_hint %}
     {%- spaceless %}
-      <span class="c-form-item__required-marker">
-        <span class="u-visually-hidden">
-          {{ 'This field is required.'|t }}
-        </span>
+      <span class="usa-hint">
+        {{ '(optional)'|t }}
       </span>
     {% endspaceless -%}
   {% endif -%}

--- a/source/04-components/form-item/form-item--checkbox/form-item--checkbox.stories.jsx
+++ b/source/04-components/form-item/form-item--checkbox/form-item--checkbox.stories.jsx
@@ -21,7 +21,6 @@ const settings = {
 
 const label = args => labelTemplate({
   ...args,
-  hide_optional_hint: true
 });
 const children = args =>
   inputTemplate({

--- a/source/04-components/form-item/form-item--checkbox/form-item--checkbox.stories.jsx
+++ b/source/04-components/form-item/form-item--checkbox/form-item--checkbox.stories.jsx
@@ -19,7 +19,10 @@ const settings = {
   },
 };
 
-const label = args => labelTemplate(args);
+const label = args => labelTemplate({
+  ...args,
+  hide_optional_hint: true
+});
 const children = args =>
   inputTemplate({
     ...args,

--- a/source/04-components/form-item/form-item--checkbox/form-item--checkbox.yml
+++ b/source/04-components/form-item/form-item--checkbox/form-item--checkbox.yml
@@ -12,3 +12,4 @@ is_required: false
 prefix: ''
 suffix: ''
 errors: ''
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--checkboxes/form-item--checkboxes.yml
+++ b/source/04-components/form-item/form-item--checkboxes/form-item--checkboxes.yml
@@ -6,3 +6,4 @@ is_required: false
 description:
   content: 'The description for this fieldset'
 id: 'checkboxes'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--radio/form-item--radio.yml
+++ b/source/04-components/form-item/form-item--radio/form-item--radio.yml
@@ -12,3 +12,4 @@ name: 'name'
 prefix: ''
 suffix: ''
 errors: ''
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--radios/form-item--radios.yml
+++ b/source/04-components/form-item/form-item--radios/form-item--radios.yml
@@ -6,3 +6,4 @@ is_required: false
 description:
   content: 'The description for this fieldset.'
 id: 'radios'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--range/form-item--range.yml
+++ b/source/04-components/form-item/form-item--range/form-item--range.yml
@@ -15,3 +15,4 @@ min: 0
 max: 100
 errors: ''
 type: 'range'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--select/form-item--select-with-groups.yml
+++ b/source/04-components/form-item/form-item--select/form-item--select-with-groups.yml
@@ -32,3 +32,4 @@ options:
         disabled: true
 errors: ''
 type: 'select'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--select/form-item--select.yml
+++ b/source/04-components/form-item/form-item--select/form-item--select.yml
@@ -30,3 +30,4 @@ options:
     disabled: true
 errors: ''
 type: 'select'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textarea/form-item--textarea.yml
+++ b/source/04-components/form-item/form-item--textarea/form-item--textarea.yml
@@ -14,3 +14,4 @@ rows: 5
 errors: ''
 value: ''
 type: 'textarea'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--color.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--color.yml
@@ -12,3 +12,4 @@ description:
   content: 'The description for this form field.'
 errors: ''
 type: 'color'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--date.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--date.yml
@@ -15,3 +15,4 @@ min: '1900-01-01'
 max: '2050-12-31'
 errors: ''
 type: 'date'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--email.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--email.yml
@@ -14,3 +14,4 @@ size: 60
 max_length: 255
 errors: ''
 type: 'email'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--file.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--file.yml
@@ -14,3 +14,4 @@ size: 22
 accept: 'image/*'
 errors: ''
 type: 'file'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--month.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--month.yml
@@ -13,3 +13,4 @@ description:
 size: 12
 errors: ''
 type: 'month'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--number-decimal.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--number-decimal.yml
@@ -13,3 +13,4 @@ description:
 step: 0.01
 errors: ''
 type: 'number'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--number-float.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--number-float.yml
@@ -13,3 +13,4 @@ description:
 step: 'any'
 errors: ''
 type: 'number'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--number-integer.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--number-integer.yml
@@ -13,3 +13,4 @@ description:
 step: 1
 errors: ''
 type: 'number'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--password.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--password.yml
@@ -14,3 +14,4 @@ size: 60
 max_length: 128
 errors: ''
 type: 'password'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--search.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--search.yml
@@ -14,3 +14,4 @@ size: 60
 max_length: 128
 errors: ''
 type: 'search'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--tel.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--tel.yml
@@ -13,3 +13,4 @@ description:
 size: 15
 errors: ''
 type: 'tel'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--text.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--text.yml
@@ -14,3 +14,4 @@ size: 60
 max_length: 128
 errors: ''
 type: 'text'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--time.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--time.yml
@@ -14,3 +14,4 @@ size: 12
 step: 1
 errors: ''
 type: 'time'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--url.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--url.yml
@@ -13,3 +13,4 @@ description:
 size: 12
 errors: ''
 type: 'url'
+hide_optional_hint: true

--- a/source/04-components/form-item/form-item--textfield/form-item--week.yml
+++ b/source/04-components/form-item/form-item--textfield/form-item--week.yml
@@ -13,3 +13,4 @@ description:
 size: 12
 errors: ''
 type: 'week'
+hide_optional_hint: true

--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -37,4 +37,5 @@
 
 {% include '@components/fieldset/fieldset.twig' with {
   modifier_classes: attributes.addClass(classes).removeClass(remove_classes).class|join(' ')|trim,
+  hide_optional_hint: type == 'fieldset'
 } %}


### PR DESCRIPTION
The relevant changes from GUS4 that I saw were replacing the * to mark required fields with (optional) to mark not required fields. Otherwise, I think we want to incorporate the changes from Gesso 5. This PR updates the templates and adds a new `hide_optional_hint` variable to turn off the (optional) when desired. (For instance, I have it turned off for default fieldsets.)

I also removed one line of CSS to use the `usa-hint` styling by default rather than our own. 