### PR TITLE
fix for aggregation error with uswds js

### DIFF
--- a/includes/libraries.inc
+++ b/includes/libraries.inc
@@ -22,6 +22,27 @@ function guswds_library_info_build() {
 }
 
 /**
+ * Implements hook_library_info_alter().
+ */
+function guswds_library_info_alter(&$libraries, $extension) {
+  // Workaround for JS errors when aggregated. Skipping uswds.es6.js, as there
+  // is some issue with drupal processing it (likely related to @uswds/uswds/js/usa-table).
+  // Based on https://www.drupal.org/project/gutenberg/issues/3372307.
+  foreach ($libraries as $name => &$library) {
+    if (empty($library['js'])) {
+      continue;
+    }
+
+    foreach ($library['js'] as $file => &$properties) {
+      if ($file == 'dist/js/uswds.es6.js') {
+        $properties['minified'] = TRUE;
+        $properties['preprocess'] = FALSE;
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_element_info_alter().
  */
 function guswds_element_info_alter(array &$types) {


### PR DESCRIPTION
For some reason, when `@uswds/uswds/js/usa-table` (which is pulled into `uswds.es6.js`) is processed by Drupal's JS aggregation, the resulting code throws an error, stopping all JS from running. This does not happen when not aggregated. and I see no issues related to this at the USWDS github. This stops that file from being minimized and aggregated. We may want to revisit this and see if its still necessary after future versions of the USWDS are released. 