### PR TITLE
hiding deprecation warnings from USWDS files

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -124,6 +124,8 @@ const config = {
               // Hiding mixed declaration warnings for now.
               // https://sass-lang.com/documentation/breaking-changes/mixed-decls/
               silenceDeprecations: ['mixed-decls'],
+              // Hiding dependency warnings due to deprecation warnings from USWDS.
+              quietDeps: true,
             },
           },
         },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -136,6 +136,8 @@ const commonConfig = {
                 // Hiding mixed declaration warnings for now.
                 // https://sass-lang.com/documentation/breaking-changes/mixed-decls/
                 silenceDeprecations: ['mixed-decls'],
+                // Hiding dependency warnings due to deprecation warnings from USWDS.
+                quietDeps: true,
               },
             },
           },

--- a/webpack.react-config.js
+++ b/webpack.react-config.js
@@ -57,6 +57,8 @@ const reactConfig = {
                   path.resolve(__dirname, 'source'),
                   './node_modules/@uswds/uswds/packages',
                 ],
+                // Hiding dependency warnings due to deprecation warnings from USWDS.
+                quietDeps: true,
               },
             },
           },


### PR DESCRIPTION
@kmonahan I added in the quietDeps settings, which removed almost all of the warnings (93 of them).  But two are still showing when I run `npm run build`.  I'm not sure why these two are different.  Can you take a look and see if you can suppress them or if it's just ok to leave them as-is for the next release?

Here are the errors I'm still seeing:

```
webpack 5.98.0 compiled with 3 warnings in 19486 ms
20 assets
172 modules

WARNING in ./source/08-react/Example/Example.module.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[3].use[2]!./source/08-react/Example/Example.module.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 13, column 6 of file:///home/clafferty/websites/gesso-uswds/node_modules/@uswds/uswds/packages/uswds-core/src/styles/functions/units/rem-to-user-em.scss:13:6:
Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

13 |   @if unit($grid-in-rem) != "rem" {


../../../@uswds/uswds/packages/uswds-core/src/styles/functions/units/rem-to-user-em.scss 14:7  rem-to-user-em()
../../../@uswds/uswds/packages/uswds-core/src/styles/mixins/helpers/at-media.scss 17:12        at-media()
../../../@uswds/uswds/packages/usa-button/src/styles/_usa-button.scss 28:3                     @forward
../../../@uswds/uswds/packages/usa-button/src/styles/_index.scss 4:1                           @forward
_index.scss 5:1                                                                                @use
../../../../source/00-config/mixins/_button.scss 8:1                                           @forward
../../../../source/00-config/mixins/_index.scss 5:1                                            @forward
_index.scss 5:1                                                                                @use
../../../../source/08-react/Example/Example.module.scss 2:1                                    root stylesheet


WARNING in ./source/08-react/Example/Example.module.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[3].use[2]!./source/08-react/Example/Example.module.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 154, column 6 of file:///home/clafferty/websites/gesso-uswds/node_modules/@uswds/uswds/packages/usa-button/src/styles/_usa-button.scss:154:6:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

154 |       color: color($button-inverse-color);


../../../@uswds/uswds/packages/usa-button/src/styles/_usa-button.scss 155:7  @forward
../../../@uswds/uswds/packages/usa-button/src/styles/_index.scss 4:1         @forward
_index.scss 5:1                                                              @use
../../../../source/00-config/mixins/_button.scss 8:1                         @forward
../../../../source/00-config/mixins/_index.scss 5:1                          @forward
_index.scss 5:1                                                              @use
../../../../source/08-react/Example/Example.module.scss 2:1                  root stylesheet


webpack 5.98.0 compiled with 2 warnings in 4624 ms
```