### PR TITLE
Fix Back to Top color contrast and colors

### DIFF
--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -446,7 +446,7 @@ gesso:
         text-hover: grayscale.white
         text-active: grayscale.white
       back-to-top:
-        background: grayscale.gray-3
+        background: grayscale.gray-4
         background-hover: grayscale.gray-5
         color: grayscale.white
         color-hover: grayscale.white

--- a/source/04-components/back-to-top/back-to-top.scss
+++ b/source/04-components/back-to-top/back-to-top.scss
@@ -2,7 +2,8 @@
 
 @use '00-config' as *;
 
-.c-back-to-top {
+// Including element selector to increase specificity and override default anchor styles
+a.c-back-to-top {
   display: none;
 
   @include breakpoint(gesso-breakpoint(mobile-lg)) {
@@ -39,6 +40,6 @@
 }
 
 // Ensure that the button is always visible (e.g., in Storybook).
-.c-back-to-top--always-visible {
+a.c-back-to-top--always-visible {
   opacity: 1 !important;
 }


### PR DESCRIPTION
@kmonahan @dcmouyard while replicating the changes from this Gesso PR (https://github.com/forumone/gesso/pull/950), I noticed that the Back-To-Top component in Gesso-UWSDS was showing the wrong color/background color. I tracked it down to the html-elements basic styles for `a {}`, which were overriding them.

The reason they're overriding them is because of the use of the not selector:
```
a:not(.usa-button, .c-button) { }
```

To compensate, I've adjusted the selector for `.c-back-to-top` to include the element, so it's now `a.c-back-to-top`, which makes it more specific and fixes the conflict.  Does this seem like a reasonable fix, or do you have other ideas?